### PR TITLE
Don't always assume int parseable keys mean the value is an array

### DIFF
--- a/jsonpointer.go
+++ b/jsonpointer.go
@@ -42,7 +42,8 @@ func Has(obj interface{}, pointer string) (rv bool) {
 				v = v.Elem()
 			}
 			token := tokens[i]
-			if n, err := strconv.Atoi(token); err == nil {
+
+			if n, err := strconv.Atoi(token); err == nil && isIndexed(v) {
 				v = v.Index(n)
 			} else {
 				v = v.MapIndex(reflect.ValueOf(token))
@@ -72,7 +73,7 @@ func Get(obj interface{}, pointer string) (rv interface{}, err error) {
 				v = v.Elem()
 			}
 			token := tokens[i]
-			if n, err := strconv.Atoi(token); err == nil {
+			if n, err := strconv.Atoi(token); err == nil && isIndexed(v) {
 				v = v.Index(n)
 			} else {
 				v = v.MapIndex(reflect.ValueOf(token))
@@ -105,7 +106,7 @@ func Set(obj interface{}, pointer string, value interface{}) (err error) {
 			}
 			p = v
 			token = tokens[i]
-			if n, err := strconv.Atoi(token); err == nil {
+			if n, err := strconv.Atoi(token); err == nil && isIndexed(v) {
 				v = v.Index(n)
 			} else {
 				v = v.MapIndex(reflect.ValueOf(token))
@@ -146,7 +147,7 @@ func Remove(obj interface{}, pointer string) (rv interface{}, err error) {
 			p = v
 			ptoken = token
 			token = tokens[i]
-			if n, err := strconv.Atoi(token); err == nil {
+			if n, err := strconv.Atoi(token); err == nil && isIndexed(v) {
 				v = v.Index(n)
 			} else {
 				v = v.MapIndex(reflect.ValueOf(token))
@@ -183,4 +184,13 @@ func Remove(obj interface{}, pointer string) (rv interface{}, err error) {
 		p.Set(reflect.ValueOf(nv))
 	}
 	return obj, nil
+}
+
+func isIndexed(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array:
+	case reflect.Slice:
+		return true
+	}
+	return false
 }

--- a/jsonpointer_test.go
+++ b/jsonpointer_test.go
@@ -18,6 +18,7 @@ var testHasCases = []struct {
 	{`{"foo":3.14}`, ``, false},
 	{`{"hoge":"fuga","foo":{"fuga":"foo1","hoge":"foo2"}}`, `/foo/fuga`, true},
 	{`{"foo~bar/baz":[1,3,true]}`, `/foo~0bar~1baz/1`, true},
+	{`{"0": [9, 8, 7]}`, `/0/1`, true},
 }
 
 func TestHas(t *testing.T) {
@@ -49,6 +50,7 @@ var testGetCases = []struct {
 	{`{"foo":3.14}`, `/`, map[string]interface{}{"foo": 3.14}, ``},
 	{`{"hoge":"fuga","foo":{"fuga":"foo1","hoge":"foo2"}}`, `/foo/fuga`, "foo1", ``},
 	{`{"foo~bar/baz":[1,3,true]}`, `/foo~0bar~1baz/1`, 3.0, ``},
+	{`{"0": [9, 8, 7]}`, `/0/1`, 8.0, ``},
 }
 
 func TestGet(t *testing.T) {
@@ -85,6 +87,7 @@ var testSetCases = []struct {
 	{`{"foo":3.14}`, `/`, 1.5, `{}`, `pointer should have element`},
 	{`{"hoge":"fuga","foo":{"fuga":"foo1","hoge":"foo2"}}`, `/foo/fuga`, 3.0, `{"hoge":"fuga","foo":{"fuga":3,"hoge":"foo2"}}`, ``},
 	{`{"foo~bar/baz":[1,3,true]}`, `/foo~0bar~1baz/1`, 4.0, `{"foo~bar/baz":[1,4,true]}`, ``},
+	{`{"0": [9, 8, 7]}`, `/0/1`, 20.0, `{"0": [9, 20, 7]}`, ``},
 }
 
 func TestSet(t *testing.T) {
@@ -122,6 +125,7 @@ var testRemoveCases = []struct {
 	{`{"foo":3.14}`, `/`, `{}`, `pointer should have element`},
 	{`{"hoge":"fuga","foo":{"fuga":"foo1","hoge":"foo2"}}`, `/foo/fuga`, `{"hoge":"fuga","foo":{"hoge":"foo2"}}`, ``},
 	{`{"foo~bar/baz":[1,3,true]}`, `/foo~0bar~1baz/1`, `{"foo~bar/baz":[1,true]}`, ``},
+	{`{"0": [9, 8, 7]}`, `/0/1`, `{"0": [9, 7]}`, ``},
 }
 
 func TestRemove(t *testing.T) {


### PR DESCRIPTION
Previously if a token was parseable to an int it was assumed that the value could have `Index(token)` called on it, that's not true for maps.

Structures like
```
{
  "0": "zero"
}
```

and pathes like /0 would cause an error